### PR TITLE
Read DB and JWT config from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,26 @@ server := NewProxyServer(":1080")
 
 ### Kết nối MySQL
 
-Chỉnh sửa thông tin kết nối MySQL trong file `main.go`:
+Server đọc cấu hình kết nối cơ sở dữ liệu từ các biến môi trường sau (giá trị mặc định trong ngoặc):
 
-```go
-db, err := sql.Open("mysql", "root:password@tcp(127.0.0.1:3306)/proxy_server")
+| Biến | Mặc định |
+|------|----------|
+| `DB_DRIVER` | `mysql` |
+| `DB_USER` | `root` |
+| `DB_PASSWORD` | `Tuan123` |
+| `DB_HOST` | `127.0.0.1` |
+| `DB_PORT` | `3306` |
+| `DB_NAME` | `proxy` |
+
+Ví dụ thiết lập trước khi chạy server:
+
+```bash
+export DB_USER=myuser
+export DB_PASSWORD=mypass
+export DB_NAME=proxy
 ```
+
+Server sẽ tự động sử dụng các giá trị này khi khởi động.
 
 ## Quản lý người dùng
 

--- a/api/README.md
+++ b/api/README.md
@@ -33,12 +33,29 @@ go run main.go
 
 ## Cấu hình
 
-Cấu hình của API được lưu trong file `config/config.go`. Bạn có thể chỉnh sửa các thông số sau:
+Cấu hình của API được lấy từ các biến môi trường sau (giá trị mặc định trong ngoặc):
 
-- `ServerPort`: Cổng mà API server sẽ lắng nghe (mặc định: 8080)
-- `DBDriver`, `DBUser`, `DBPassword`, `DBName`, `DBHost`, `DBPort`: Thông tin kết nối đến cơ sở dữ liệu MySQL
-- `JWTSecret`, `JWTExpiration`: Cấu hình JWT
-- `AdminUsers`: Danh sách các tài khoản được phép sử dụng API
+| Biến | Mặc định | Mô tả |
+|------|----------|------|
+| `SERVER_PORT` | `8080` | Cổng lắng nghe của API |
+| `DB_DRIVER` | `mysql` | Loại cơ sở dữ liệu |
+| `DB_USER` | `root` | Tên người dùng cơ sở dữ liệu |
+| `DB_PASSWORD` | `Tuan123` | Mật khẩu cơ sở dữ liệu |
+| `DB_NAME` | `proxy` | Tên cơ sở dữ liệu |
+| `DB_HOST` | `127.0.0.1` | Địa chỉ máy chủ cơ sở dữ liệu |
+| `DB_PORT` | `3306` | Cổng cơ sở dữ liệu |
+| `JWT_SECRET` | `Oegjsc1029384756` | Khóa bí mật ký JWT |
+| `JWT_EXPIRATION` | `24` | Thời hạn token (giờ) |
+
+Ví dụ thiết lập trước khi chạy API server:
+
+```bash
+export DB_USER=myuser
+export DB_PASSWORD=mypass
+export JWT_SECRET=mysecret
+```
+
+`AdminUsers` vẫn được định nghĩa trong `config/config.go`.
 
 ## API Endpoints
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -1,22 +1,45 @@
 package config
 
+import (
+	"os"
+	"strconv"
+)
+
+// getEnv returns the value of the environment variable named by key or the fallback value.
+func getEnv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// getEnvInt returns the integer value of the environment variable or the fallback value.
+func getEnvInt(key string, fallback int) int {
+	if value := os.Getenv(key); value != "" {
+		if v, err := strconv.Atoi(value); err == nil {
+			return v
+		}
+	}
+	return fallback
+}
+
 // ServerPort là cổng mà API server sẽ lắng nghe
-const ServerPort = "8080"
+var ServerPort = getEnv("SERVER_PORT", "8080")
 
 // DatabaseConfig chứa thông tin kết nối đến cơ sở dữ liệu
-const (
-	DBDriver   = "mysql"
-	DBUser     = "root"
-	DBPassword = "Tuan123"
-	DBName     = "proxy"
-	DBHost     = "127.0.0.1"
-	DBPort     = "3306"
+var (
+	DBDriver   = getEnv("DB_DRIVER", "mysql")
+	DBUser     = getEnv("DB_USER", "root")
+	DBPassword = getEnv("DB_PASSWORD", "Tuan123")
+	DBName     = getEnv("DB_NAME", "proxy")
+	DBHost     = getEnv("DB_HOST", "127.0.0.1")
+	DBPort     = getEnv("DB_PORT", "3306")
 )
 
 // JWTConfig chứa các cấu hình liên quan đến JWT
-const (
-	JWTSecret     = "Oegjsc1029384756" // Khóa bí mật để ký JWT
-	JWTExpiration = 24                        // Thời gian hết hạn của token (giờ)
+var (
+	JWTSecret     = getEnv("JWT_SECRET", "Oegjsc1029384756") // Khóa bí mật để ký JWT
+	JWTExpiration = getEnvInt("JWT_EXPIRATION", 24)          // Thời gian hết hạn của token (giờ)
 )
 
 // AdminUsers là danh sách các tài khoản được phép sử dụng API

--- a/main.go
+++ b/main.go
@@ -57,6 +57,15 @@ const (
 	BURST_LIMIT = 100 * 1024 * 1024  // 100 MB burst - thực tế là không giới hạn
 )
 
+// getEnv returns the value of the environment variable named by the key.
+// It returns the fallback value if the variable is not set.
+func getEnv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
 // User credentials for authentication
 type User struct {
 	Username      string
@@ -86,8 +95,15 @@ func NewProxyServer(addr string) *ProxyServer {
 	logHandler := slog.NewTextHandler(os.Stdout, logOpts)
 	logger := slog.New(logHandler)
 
-	// Connect to MySQL database
-	db, err := sql.Open("mysql", "root:Tuan123@tcp(127.0.0.1:3306)/proxy")
+	// Connect to MySQL database using environment variables
+	dbUser := getEnv("DB_USER", "root")
+	dbPassword := getEnv("DB_PASSWORD", "Tuan123")
+	dbHost := getEnv("DB_HOST", "127.0.0.1")
+	dbPort := getEnv("DB_PORT", "3306")
+	dbName := getEnv("DB_NAME", "proxy")
+	dbDriver := getEnv("DB_DRIVER", "mysql")
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", dbUser, dbPassword, dbHost, dbPort, dbName)
+	db, err := sql.Open(dbDriver, dsn)
 	if err != nil {
 		logger.Error("Failed to connect to database", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Load database connection details from environment variables in proxy server
- Configure API server to pull database and JWT settings from environment variables
- Document required environment variables for proxy and API servers

## Testing
- `go build ./...`
- `cd api && go build ./... && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_689e1f756f80832a99aa20a5439a95d4